### PR TITLE
Fix HDR in stock Camera; enable Camera2 API; attempt to fix VoLTE

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -43,7 +43,7 @@ bluetooth.hfp.client=1
 qcom.bluetooth.soc=smd
 
 # Camera
-persist.camera.HAL3.enabled=0
+persist.camera.HAL3.enabled=1
 persist.camera.isp.clock.optmz=0
 vidc.enc.dcvs.extra-buff-count=2
 media.camera.ts.monotonic=1
@@ -54,7 +54,7 @@ persist.camera.feature.cac=1
 persist.camera.imglib.cac3=2
 camera.lowpower.record.enable=1
 persist.camera.gyro.disable=0
-camera.hal1.packagelist=com.skype.raider,com.google.android.talk
+camera.hal1.packagelist=com.skype.raider,com.google.android.talk,org.cyanogenmod.snap,com.android.server.telecom,com.android.dialer,com.android.providers.telephony,com.android.phone,com.qualcomm.qti.telephonyservice
 
 # Cne
 persist.cne.feature=1


### PR DESCRIPTION
* change persist.camera.HAL3.enabled=0 to persist.camera.HAL3.enabled=1
* add org.cyanogenmod.snap to camera.hal1.packagelist so Camera2 API is available system-wide, except for the stock Camera: this enables HDR in stock Camera
* add com.android.server.telecom,com.android.dialer,com.android.providers.telephony,com.android.phone,com.qualcomm.qti.telephonyservice to camera.hal1.packagelist in an attempt to fix VoLTE while Camera2 API is enabled.